### PR TITLE
[Fix] OSコマンドをエスケープして実行するようにした

### DIFF
--- a/src/app/Http/Controllers/ImageController.php
+++ b/src/app/Http/Controllers/ImageController.php
@@ -27,7 +27,8 @@ class ImageController extends Controller
                 return response()->json(['message' => 'ファイルサイズが大きすぎます'], 404);
             }
             $tmpPath = public_path() . "/storage/tmp/".uniqid().'.png';
-            exec('convert '.$path.' -resize '.$x.'x'.$y.'! '.$tmpPath);
+            $cmd = escapeshellcmd('convert '.$path.' -resize '.$x.'x'.$y.'! '.$tmpPath);
+            exec($cmd);
             return response()->file($tmpPath);
         }
         return response()->file($path);


### PR DESCRIPTION
コマンドは `escapeshellcmd` 関数をかまして、良きせぬ文字列エスケープするようにしました。

以前は
`http://localhost/api/image?file=goods/2.png&x=100&y=1001;echo 'hogehoge'> /var/www/laravel/tmp/sample.txt;`

で任意ファイルの作成ができていましたが、変更後はできなくなっています。 
